### PR TITLE
Fix ./mach run on Windows

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -88,6 +88,9 @@ git = "https://github.com/servo/rust-fontconfig"
 [target.arm-linux-androideabi.dependencies.fontconfig]
 git = "https://github.com/servo/rust-fontconfig"
 
+[target.x86_64-pc-windows-gnu.dependencies.fontconfig]
+git = "https://github.com/servo/rust-fontconfig"
+
 [target.i686-unknown-linux-gnu.dependencies.freetype]
 git = "https://github.com/servo/rust-freetype"
 
@@ -101,6 +104,9 @@ git = "https://github.com/servo/rust-freetype"
 git = "https://github.com/servo/rust-freetype"
 
 [target.arm-linux-androideabi.dependencies.freetype]
+git = "https://github.com/servo/rust-freetype"
+
+[target.x86_64-pc-windows-gnu.dependencies.freetype]
 git = "https://github.com/servo/rust-freetype"
 
 [target.x86_64-apple-darwin.dependencies.core-text]

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use azure::azure_hl::BackendType;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 use azure::scaled_font::FontInfo;
 use azure::scaled_font::ScaledFont;
 use fnv::FnvHasher;
@@ -31,7 +31,7 @@ use style::computed_values::{font_style, font_variant};
 use util::cache::HashCache;
 use util::mem::HeapSizeOf;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 fn create_scaled_font(template: &Arc<FontTemplateData>, pt_size: Au) -> ScaledFont {
     ScaledFont::new(BackendType::Skia, FontInfo::FontData(&template.bytes),
                     pt_size.to_f32_px())

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -4,7 +4,7 @@
 
 // For simd (currently x86_64/aarch64)
 #![cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), feature(convert))]
-#![cfg_attr(any(target_os = "linux", target_os = "android"), feature(heap_api))]
+#![cfg_attr(any(target_os = "linux", target_os = "android", target_os = "windows"), feature(heap_api))]
 
 #![feature(alloc)]
 #![feature(box_syntax)]
@@ -43,10 +43,10 @@ extern crate canvas_traits;
 extern crate euclid;
 extern crate fnv;
 
-// Linux and Android-specific library dependencies
-#[cfg(any(target_os = "linux", target_os = "android"))]
+// Platforms that use Freetype/Fontconfig library dependencies
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 extern crate fontconfig;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 extern crate freetype;
 
 extern crate gfx_traits;
@@ -75,7 +75,6 @@ extern crate style;
 extern crate time;
 extern crate unicode_script;
 extern crate url;
-
 
 pub use paint_context::PaintContext;
 

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -150,3 +150,10 @@ pub fn last_resort_font_families() -> Vec<String> {
 pub fn last_resort_font_families() -> Vec<String> {
     vec!("Roboto".to_owned())
 }
+
+#[cfg(target_os = "windows")]
+pub fn get_last_resort_font_families() -> Vec<String> {
+    vec!(
+        "Arial".to_owned()
+    )
+}

--- a/components/gfx/platform/mod.rs
+++ b/components/gfx/platform/mod.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 pub use platform::freetype::{font, font_context, font_list, font_template};
 
 #[cfg(target_os = "macos")]
 pub use platform::macos::{font, font_context, font_list, font_template};
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
 pub mod freetype {
     pub mod font;
     pub mod font_context;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1905,6 +1905,7 @@ dependencies = [
  "hyper 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -49,7 +49,7 @@ fn main() {
     let window = if opts::get().headless {
         None
     } else {
-        Some(app::create_window(std::ptr::null_mut()))
+        Some(app::create_window(None))
     };
 
     // Our wrapper around `Browser` that also implements some

--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -8,12 +8,32 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio, exit};
 
+#[cfg(windows)]
+fn find_python() -> String {
+    if Command::new("python27.exe").arg("--version").output().is_ok() {
+        return "python27.exe".to_owned();
+    }
 
-fn main() {
-    let python = if Command::new("python2.7").arg("--version").output().unwrap().status.success() {
+    if Command::new("python.exe").arg("--version").output().is_ok() {
+        return "python.exe".to_owned();
+    }
+
+    panic!("Can't find python (tried python27.exe and python.exe)! Try fixing PATH or setting the PYTHON env var");
+}
+
+#[cfg(not(windows))]
+fn find_python() -> String {
+    if Command::new("python2.7").arg("--version").output().unwrap().status.success() {
         "python2.7"
     } else {
         "python"
+    }.to_owned()
+}
+
+fn main() {
+    let python = match env::var("PYTHON") {
+        Ok(python_path) => python_path,
+        Err(_) => find_python(),
     };
     let style = Path::new(file!()).parent().unwrap();
     let mako = style.join("Mako-0.9.1.zip");

--- a/components/util/Cargo.toml
+++ b/components/util/Cargo.toml
@@ -59,3 +59,6 @@ string_cache = "0.1"
 lazy_static = "0.1"
 getopts = "0.2.11"
 hyper = "0.6"
+
+[target.x86_64-pc-windows-gnu.dependencies]
+kernel32-sys = "0.1.4"

--- a/components/util/workqueue.rs
+++ b/components/util/workqueue.rs
@@ -7,7 +7,11 @@
 //! Data associated with queues is simply a pair of unsigned integers. It is expected that a
 //! higher-level API on top of this could allow safe fork-join parallelism.
 
+#[cfg(windows)]
+extern crate kernel32;
+
 use deque::{Abort, BufferPool, Data, Empty, Stealer, Worker};
+#[cfg(not(windows))]
 use libc::funcs::posix88::unistd::usleep;
 use rand::{Rng, XorShiftRng, weak_rng};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -92,6 +96,20 @@ fn next_power_of_two(mut v: u32) -> u32 {
     v
 }
 
+#[cfg(not(windows))]
+fn sleep_microseconds(usec: u32) {
+    unsafe {
+        usleep(usec);
+    }
+}
+
+#[cfg(windows)]
+fn sleep_microseconds(usec: u32) {
+    unsafe {
+        kernel32::Sleep(0);
+    }
+}
+
 impl<QueueData: Sync, WorkData: Send> WorkerThread<QueueData, WorkData> {
     /// The main logic. This function starts up the worker and listens for
     /// messages.
@@ -151,9 +169,8 @@ impl<QueueData: Sync, WorkData: Send> WorkerThread<QueueData, WorkData> {
                                     }
                                 }
 
-                                unsafe {
-                                    usleep(back_off_sleep as u32);
-                                }
+                                sleep_microseconds(back_off_sleep);
+
                                 back_off_sleep += BACKOFF_INCREMENT_IN_US;
                                 i = 0
                             } else {

--- a/ports/glutin/lib.rs
+++ b/ports/glutin/lib.rs
@@ -37,7 +37,7 @@ pub trait NestedEventLoopListener {
     fn handle_event_from_nested_event_loop(&mut self, event: WindowEvent) -> bool;
 }
 
-pub fn create_window(parent: WindowID) -> Rc<Window> {
+pub fn create_window(parent: Option<WindowID>) -> Rc<Window> {
     // Read command-line options.
     let opts = opts::get();
     let foreground = opts.output_file.is_none();

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -84,7 +84,7 @@ pub struct Window {
 impl Window {
     pub fn new(is_foreground: bool,
                window_size: TypedSize2D<DevicePixel, u32>,
-               parent: glutin::WindowID) -> Rc<Window> {
+               parent: Option<glutin::WindowID>) -> Rc<Window> {
         let mut glutin_window = glutin::WindowBuilder::new()
                             .with_title("Servo".to_string())
                             .with_decorations(!opts::get().no_native_titlebar)
@@ -121,7 +121,9 @@ impl Window {
     }
 
     pub fn platform_window(&self) -> glutin::WindowID {
-        unsafe { self.window.platform_window() }
+        unsafe {
+            glutin::WindowID::new(self.window.platform_window())
+        }
     }
 
     fn nested_window_resize(width: u32, height: u32) {
@@ -288,7 +290,7 @@ impl Window {
         self.event_queue.borrow_mut().push(WindowEvent::MouseWindowEventClass(event));
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     fn handle_next_event(&self) -> bool {
         let event = self.window.wait_events().next().unwrap();
         let mut close = self.handle_window_event(event);
@@ -718,7 +720,7 @@ pub struct Window {
 impl Window {
     pub fn new(_is_foreground: bool,
                window_size: TypedSize2D<DevicePixel, u32>,
-               _parent: glutin::WindowID) -> Rc<Window> {
+               _parent: Option<glutin::WindowID>) -> Rc<Window> {
         let window_size = window_size.to_untyped();
         let headless_builder = glutin::HeadlessRendererBuilder::new(window_size.width,
                                                                     window_size.height);

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -28,7 +28,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, cd, host_triple
+from servo.command_base import CommandBase, cd, host_triple, use_nightly_rust, check_call, BIN_SUFFIX
 
 
 def download(desc, src, writer):
@@ -118,7 +118,7 @@ class MachCommands(CommandBase):
     def bootstrap_rustc(self, force=False):
         rust_dir = path.join(
             self.context.sharedir, "rust", *self.rust_snapshot_path().split("/"))
-        if not force and path.exists(path.join(rust_dir, "rustc", "bin", "rustc")):
+        if not force and path.exists(path.join(rust_dir, "rustc", "bin", "rustc" + BIN_SUFFIX)):
             print("Snapshot Rust compiler already downloaded.", end=" ")
             print("Use |bootstrap-rust --force| to download again.")
             return
@@ -130,6 +130,10 @@ class MachCommands(CommandBase):
         snapshot_url = ("https://servo-rust.s3.amazonaws.com/%s.tar.gz"
                         % self.rust_snapshot_path())
         tgz_file = rust_dir + '.tar.gz'
+
+        if use_nightly_rust():
+            snapshot_url = ("https://static.rust-lang.org/dist/%s.tar.gz"
+                            % self.rust_snapshot_path())
 
         download_file("Rust snapshot", snapshot_url, tgz_file)
 
@@ -184,7 +188,7 @@ class MachCommands(CommandBase):
     def bootstrap_cargo(self, force=False):
         cargo_dir = path.join(self.context.sharedir, "cargo",
                               self.cargo_build_id())
-        if not force and path.exists(path.join(cargo_dir, "bin", "cargo")):
+        if not force and path.exists(path.join(cargo_dir, "cargo", "bin", "cargo" + BIN_SUFFIX)):
             print("Cargo already downloaded.", end=" ")
             print("Use |bootstrap-cargo --force| to download again.")
             return
@@ -270,9 +274,9 @@ class MachCommands(CommandBase):
                                   % module_path)
                             print("\nClean the submodule and try again.")
                             return 1
-        subprocess.check_call(
+        check_call(
             ["git", "submodule", "--quiet", "sync", "--recursive"])
-        subprocess.check_call(
+        check_call(
             ["git", "submodule", "update", "--init", "--recursive"])
 
     @Command('clean-snapshots',

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -11,7 +11,6 @@ from __future__ import print_function, unicode_literals
 
 import os
 import os.path as path
-import subprocess
 import sys
 
 from time import time
@@ -22,7 +21,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, cd
+from servo.command_base import CommandBase, cd, call
 
 
 def is_headless_build():
@@ -110,14 +109,6 @@ def notify(title, text):
         except Exception as e:
             extra = getattr(e, "message", "")
             print("[Warning] Could not generate notification! %s" % extra, file=sys.stderr)
-
-
-def call(*args, **kwargs):
-    """Wrap `subprocess.call`, printing the command if verbose=True."""
-    verbose = kwargs.pop('verbose', False)
-    if verbose:
-        print(' '.join(args[0]))
-    return subprocess.call(*args, **kwargs)
 
 
 @CommandProvider

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -223,6 +223,14 @@ class CommandBase(object):
     def build_env(self, gonk=False, hosts_file_path=None):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
+        if sys.platform == "win32" and type(env['PATH']) == unicode:
+            # On win32, the virtualenv's activate_this.py script sometimes ends up
+            # turning os.environ['PATH'] into a unicode string.  This doesn't work
+            # for passing env vars in to a process, so we force it back to ascii.
+            # We don't use UTF8 since that won't be correct anyway; if you actually
+            # have unicode stuff in your path, all this PATH munging would have broken
+            # it in any case.
+            env['PATH'] = env['PATH'].encode('ascii', 'ignore')
         extra_path = []
         extra_lib = []
         if not self.config["tools"]["system-rust"] \

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -10,7 +10,6 @@
 from __future__ import print_function, unicode_literals
 from os import path, getcwd, listdir
 
-import subprocess
 import sys
 
 from mach.decorators import (
@@ -19,7 +18,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, cd
+from servo.command_base import CommandBase, cd, call
 
 
 @CommandProvider
@@ -36,10 +35,8 @@ class MachCommands(CommandBase):
 
         if self.context.topdir == getcwd():
             with cd(path.join('components', 'servo')):
-                return subprocess.call(
-                    ["cargo"] + params, env=self.build_env())
-        return subprocess.call(['cargo'] + params,
-                               env=self.build_env())
+                return call(["cargo"] + params, env=self.build_env())
+        return call(['cargo'] + params, env=self.build_env())
 
     @Command('cargo-update',
              description='Same as update-cargo',
@@ -88,8 +85,8 @@ class MachCommands(CommandBase):
         for cargo_path in cargo_paths:
             with cd(cargo_path):
                 print(cargo_path)
-                subprocess.call(["cargo", "update"] + params,
-                                env=self.build_env())
+                call(["cargo", "update"] + params,
+                     env=self.build_env())
 
     @Command('rustc',
              description='Run the Rust compiler',
@@ -100,7 +97,7 @@ class MachCommands(CommandBase):
     def rustc(self, params):
         if params is None:
             params = []
-        return subprocess.call(["rustc"] + params, env=self.build_env())
+        return call(["rustc"] + params, env=self.build_env())
 
     @Command('rust-root',
              description='Print the path to the root of the Rust compiler',
@@ -129,7 +126,7 @@ class MachCommands(CommandBase):
         root_dirs_abs = [path.join(self.context.topdir, s) for s in root_dirs]
         # Absolute paths for all directories to be considered
         grep_paths = root_dirs_abs + tests_dirs_abs
-        return subprocess.call(
+        return call(
             ["git"] + ["grep"] + params + ['--'] + grep_paths + [':(exclude)*.min.js'],
             env=self.build_env())
 
@@ -138,14 +135,14 @@ class MachCommands(CommandBase):
              category='devenv')
     def upgrade_wpt_runner(self):
         with cd(path.join(self.context.topdir, 'tests', 'wpt', 'harness')):
-            code = subprocess.call(["git", "init"], env=self.build_env())
+            code = call(["git", "init"], env=self.build_env())
             if code:
                 return code
-            subprocess.call(
+            call(
                 ["git", "remote", "add", "upstream", "https://github.com/w3c/wptrunner.git"], env=self.build_env())
-            code = subprocess.call(["git", "fetch", "upstream"], env=self.build_env())
+            code = call(["git", "fetch", "upstream"], env=self.build_env())
             if code:
                 return code
-            code = subprocess.call(["git", "reset", '--', "hard", "remotes/upstream/master"], env=self.build_env())
+            code = call(["git", "reset", '--', "hard", "remotes/upstream/master"], env=self.build_env())
             if code:
                 return code

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -22,7 +22,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase
+from servo.command_base import CommandBase, call, check_call
 
 
 def read_file(filename, if_exists=False):
@@ -79,7 +79,7 @@ class MachCommands(CommandBase):
             args = args + params
 
         try:
-            subprocess.check_call(args, env=env)
+            check_call(args, env=env)
         except subprocess.CalledProcessError as e:
             print("Servo exited with return value %d" % e.returncode)
             return e.returncode
@@ -107,7 +107,7 @@ class MachCommands(CommandBase):
         servo_cmd = [self.get_binary_path(release, dev)] + params
         rr_cmd = ['rr', '--fatal-errors', 'record']
         try:
-            subprocess.check_call(rr_cmd + servo_cmd)
+            check_call(rr_cmd + servo_cmd)
         except OSError as e:
             if e.errno == 2:
                 print("rr binary can't be found!")
@@ -119,7 +119,7 @@ class MachCommands(CommandBase):
              category='post-build')
     def rr_replay(self):
         try:
-            subprocess.check_call(['rr', '--fatal-errors', 'replay'])
+            check_call(['rr', '--fatal-errors', 'replay'])
         except OSError as e:
             if e.errno == 2:
                 print("rr binary can't be found!")
@@ -156,8 +156,8 @@ class MachCommands(CommandBase):
                     else:
                         copy2(full_name, destination)
 
-        return subprocess.call(["cargo", "doc"] + params,
-                               env=self.build_env(), cwd=self.servo_crate())
+        return call(["cargo", "doc"] + params,
+                    env=self.build_env(), cwd=self.servo_crate())
 
     @Command('browse-doc',
              description='Generate documentation and open it in a web browser',

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -14,7 +14,6 @@ import re
 import sys
 import os
 import os.path as path
-import subprocess
 from collections import OrderedDict
 from time import time
 
@@ -25,7 +24,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase
+from servo.command_base import CommandBase, call, check_call
 from wptrunner import wptcommandline
 from update import updatecommandline
 import tidy
@@ -65,7 +64,7 @@ class MachCommands(CommandBase):
     def run_test(self, prefix, args=[], release=False):
         t = self.find_test(prefix, release=release)
         if t:
-            return subprocess.call([t] + args, env=self.build_env())
+            return call([t] + args, env=self.build_env())
 
     @Command('test',
              description='Run all Servo tests',
@@ -179,7 +178,7 @@ class MachCommands(CommandBase):
         for crate in packages:
             args += ["-p", "%s_tests" % crate]
         args += test_patterns
-        result = subprocess.call(args, env=self.build_env(), cwd=self.servo_crate())
+        result = call(args, env=self.build_env(), cwd=self.servo_crate())
         if result != 0:
             return result
 
@@ -252,7 +251,7 @@ class MachCommands(CommandBase):
              category='testing')
     def test_wpt_failure(self):
         self.ensure_bootstrapped()
-        return not subprocess.call([
+        return not call([
             "bash",
             path.join("tests", "wpt", "run.sh"),
             "--no-pause-after-test",
@@ -411,17 +410,17 @@ class MachCommands(CommandBase):
 
         # Clone the jQuery repository if it doesn't exist
         if not os.path.isdir(jquery_dir):
-            subprocess.check_call(
+            check_call(
                 ["git", "clone", "-b", "servo", "--depth", "1", "https://github.com/servo/jquery", jquery_dir])
 
         # Run pull in case the jQuery repo was updated since last test run
-        subprocess.check_call(
+        check_call(
             ["git", "-C", jquery_dir, "pull"])
 
         # Check that a release servo build exists
         bin_path = path.abspath(self.get_binary_path(release, dev))
 
-        return subprocess.check_call(
+        return check_call(
             [run_file, cmd, bin_path, base_dir])
 
     def dromaeo_test_runner(self, tests, release, dev):
@@ -432,19 +431,19 @@ class MachCommands(CommandBase):
 
         # Clone the Dromaeo repository if it doesn't exist
         if not os.path.isdir(dromaeo_dir):
-            subprocess.check_call(
+            check_call(
                 ["git", "clone", "-b", "servo", "--depth", "1", "https://github.com/notriddle/dromaeo", dromaeo_dir])
 
         # Run pull in case the Dromaeo repo was updated since last test run
-        subprocess.check_call(
+        check_call(
             ["git", "-C", dromaeo_dir, "pull"])
 
         # Compile test suite
-        subprocess.check_call(
+        check_call(
             ["make", "-C", dromaeo_dir, "web"])
 
         # Check that a release servo build exists
         bin_path = path.abspath(self.get_binary_path(release, dev))
 
-        return subprocess.check_call(
+        return check_call(
             [run_file, "|".join(tests), bin_path, base_dir])


### PR DESCRIPTION
Fix unicode PATH the same way as mozilla-central does it for windows.
Also append extra PATHs instead of prepending, for some reason that broke ./mach run
